### PR TITLE
fix php error on order page

### DIFF
--- a/omnivaltshipping.php
+++ b/omnivaltshipping.php
@@ -1111,7 +1111,7 @@ class OmnivaltShipping extends CarrierModule
                 'moduleurl' => $this->context->link->getAdminLink(self::CONTROLLER_OMNIVA_AJAX) . '&action=saveOrderInfo',
                 'generateLabelsUrl' => $this->context->link->getAdminLink(self::CONTROLLER_OMNIVA_AJAX) . '&action=generateLabels',
                 'printLabelsUrl' => $printLabelsUrl,
-                'is_tracked' => count(json_decode($omnivaOrder->tracking_numbers)) > 0,
+                'is_tracked' => count((array)json_decode($omnivaOrder->tracking_numbers)) > 0,
                 'error' => $error_msg,
                 'orderHistory' => OmnivaOrderHistory::getHistoryByOrder($omnivaOrder->id),
             ));


### PR DESCRIPTION
Fixes PHP error on order page when no label has been generated yet

Warning on PHP7
![image](https://github.com/mijora/omniva-prestashop-1.6-1.7/assets/58936586/8aa0f5a1-15a6-4ff6-988f-4fc9e3e67f5f)

Error on PHP8
![image](https://github.com/mijora/omniva-prestashop-1.6-1.7/assets/58936586/b748003c-46ee-469c-92a5-a54cfea35117)
